### PR TITLE
Fix python output in docker container output

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,4 +22,4 @@ services:
       - ./app:/app
     depends_on:
       - db
-    entrypoint: ["python", "-m", "flask", "run", "--host=0.0.0.0"]
+    entrypoint: ["python", "-u", "-m", "flask", "run", "--host=0.0.0.0"]


### PR DESCRIPTION
Docker now displays output of python print statements for easy debugging.